### PR TITLE
IPASIP-2358 = Support transport map and recipient BCC map config files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ TLS and OpenDKIM support are optional.
 1. Build image
 
 	```bash
-	$ sudo docker pull catatnight/postfix
+	$ sudo docker pull agiledigital/postfix
 	```
 
 ## Usage
@@ -20,7 +20,7 @@ TLS and OpenDKIM support are optional.
 	```bash
 	$ sudo docker run -p 25:25 \
 			-e maildomain=mail.example.com -e smtp_user=user:pwd \
-			--name postfix -d catatnight/postfix
+			--name postfix -d agiledigital/postfix
 	# Set multiple user credentials: -e smtp_user=user1:pwd1,user2:pwd2,...,userN:pwdN
 	```
 2. Enable OpenDKIM: save your domain key ```.private``` in ```/path/to/domainkeys```
@@ -29,7 +29,7 @@ TLS and OpenDKIM support are optional.
 	$ sudo docker run -p 25:25 \
 			-e maildomain=mail.example.com -e smtp_user=user:pwd \
 			-v /path/to/domainkeys:/etc/opendkim/domainkeys \
-			--name postfix -d catatnight/postfix
+			--name postfix -d agiledigital/postfix
 	```
 3. Enable TLS(587): save your SSL certificates ```.key``` and ```.crt``` to  ```/path/to/certs```
 
@@ -37,7 +37,7 @@ TLS and OpenDKIM support are optional.
 	$ sudo docker run -p 587:587 \
 			-e maildomain=mail.example.com -e smtp_user=user:pwd \
 			-v /path/to/certs:/etc/postfix/certs \
-			--name postfix -d catatnight/postfix
+			--name postfix -d agiledigital/postfix
 	```
 
 ## Note

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-docker build -t catatnight/postfix .
+version_tag="$(date '+%Y%m%d')"
+set -x
+docker build -t agiledigital/postfix:latest $@ .
+docker tag agiledigital/postfix:latest "agiledigital/postfix:$version_tag"


### PR DESCRIPTION
We need to use these config files when we run Postfix in staging, so we can make sure it can’t accidentally send emails to actual users.